### PR TITLE
Fix off-by-one error

### DIFF
--- a/MossSideWhist.java
+++ b/MossSideWhist.java
@@ -75,7 +75,7 @@ public class MossSideWhist{
   display(leader); display(left); display(right);  
     Card[] discard = agents.get(leader).discard();
     for(int i = 0; i<4; i++){
-      if(i>discard.length || !hands.get(leader).remove(discard[i]))
+      if(i>=discard.length || !hands.get(leader).remove(discard[i]))
         hands.get(leader).remove(0);//if illegitimate discards, the 0 card is discarded.
         //could include a score penalty here as well.
         display(leader);


### PR DESCRIPTION
The out-of-bounds check between `i` and `discard.length` should use `>=` not `>`.